### PR TITLE
[ptn] fixed wrong pixel format on texture re-creation

### DIFF
--- a/Source/WebCameraFeed/Private/DirectShowVideoGrabber.cpp
+++ b/Source/WebCameraFeed/Private/DirectShowVideoGrabber.cpp
@@ -104,7 +104,7 @@ void DirectShowVideoGrabber::update() {
 				int w = width;
 				int h = height;
 				AsyncTask(ENamedThreads::GameThread, [this, w, h, fSemaphore]() {
-					this->resizeData(w, h, PF_B8G8R8A8);
+					this->resizeData(w, h);
 					fSemaphore->Trigger();
 				});
 				fSemaphore->Wait();


### PR DESCRIPTION
The texture is originally created with pixel format `PF_R8G8B8A8`, however, inside `update()` routine if texture is invalid, it is being re-allocated again but with pixel format `PF_B8G8R8A8` which results in camera image texture having R and B channels swapped. 
This commit fixes this issue by removing pixel format argument passed to `resizeData()` thus falling back to the default value of `PF_R8G8B8A8`.