### PR TITLE
Fixed comparison that always set device ID to highest available

### DIFF
--- a/Source/WebCameraFeed/Private/WebCameraComponent.cpp
+++ b/Source/WebCameraFeed/Private/WebCameraComponent.cpp
@@ -25,7 +25,7 @@ void UWebCameraComponent::BeginPlay()
 
 	TArray<FString> devices = ListDevices();
 
-	if (devices.Num() >= DeviceId.selectedDevice) {
+	if (DeviceId.selectedDevice >= devices.Num()) {
 		DeviceId.selectedDevice = devices.Num() - 1;
 	}
 


### PR DESCRIPTION
The two sides of the comparison were the wrong way round which forced a valid selectedDevice to the highest ID available.